### PR TITLE
Makefile: make the `default` task actually the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 PLATFORM = linux
 
-clean:
-	$(MAKE) -C src/lua/src clean
-
 default:
 	$(MAKE) -C src/lua/src $(PLATFORM)
 	$(MAKE) -C src
+
+
+clean:
+	$(MAKE) -C src/lua/src clean


### PR DESCRIPTION
Make uses the first task in the Makefile as the default.
`clean` was first, so running `make` would do `make clean`,
instead of the desired `make default`.